### PR TITLE
Fixes getErrorCount

### DIFF
--- a/clients/validations.js
+++ b/clients/validations.js
@@ -66,7 +66,7 @@ class Validators {
 
     getErrorCount(validationErrors) {
         return Object.keys(validationErrors).reduce(function (previous, current) {
-            return validationErrors[current].length;
+            return previous + validationErrors[current].length;
         }, 0);
     }
 


### PR DESCRIPTION
Previously 'previous' results were not taken into consideration and number of errors in last key was returned.